### PR TITLE
Fixed word length bug

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -10,7 +10,10 @@ class Dictionary {
     constructor(words) {
         this.length = undefined;
         this.words = [];
-        for (const w of words) {
+        for (var w of words) {
+            // Slices off an invisible character at the end when reading the file
+            w = w.slice(0,-1)    
+
             if (this.length === undefined) {
                 this.length = w.length
             } else if (this.length !== w.length) {


### PR DESCRIPTION
I encountered this bug where the word length was 1 more than it should have been.
ie: when playing the US version of the game there were 6 boxes per row instead of the intended 5 - making the game impossible as there are only 5 lettered words in the dictionary used.

Turns out when reading the file in dictionary.js there is an invisible character at the end of each word, so I sliced off the last character ('w' is now a variable instead of a constant).

Using Chrome Version 119.0.6045.200